### PR TITLE
Cast COCO IDs to strings

### DIFF
--- a/src/Annotation.php
+++ b/src/Annotation.php
@@ -27,7 +27,7 @@ class Annotation
         $instance->image_id = (string) $data['image_id'];
         $instance->category_id = (string) $data['category_id'];
 
-        if (isset($data['segmentation'])){
+        if (isset($data['segmentation']) && !empty($data['segmentation'])){
             $instance->segmentation = is_array($data['segmentation'][0]) ? $data['segmentation'][0] : $data['segmentation'];
         } elseif (isset($data['bbox'])) {
             // Populate segmentation from bbox: [x, y, width, height] => rectangle
@@ -59,10 +59,22 @@ class Annotation
             if (is_null($data[$key])) {
                 throw new \Exception("Missing value for '$key' in Annotation");
             }
+            if (!is_scalar($data[$key])) {
+                throw new \Exception("Invalid value for '$key' in Annotation");
+            }
         }
         // At least one of segmentation or bbox must be provided
         if (!isset($data['segmentation']) && !isset($data['bbox'])) {
             throw new \Exception("Annotation must have at least 'segmentation' or 'bbox' field");
+        }
+        if (isset($data['segmentation'])) {
+            if (!is_array($data['segmentation'])) {
+                throw new \Exception("Invalid value for 'segmentation' in Annotation");
+            }
+
+            if (empty($data['segmentation']) && !isset($data['bbox'])) {
+                throw new \Exception("Missing value for 'segmentation' in Annotation");
+            }
         }
     }
 

--- a/src/Annotation.php
+++ b/src/Annotation.php
@@ -9,9 +9,9 @@ use Biigle\Services\MetadataParsing\LabelAndUser;
 
 class Annotation
 {
-    public int $id;
-    public int $image_id;
-    public int $category_id;
+    public string $id;
+    public string $image_id;
+    public string $category_id;
     public ?array $segmentation = null;
     public ?array $bbox = null;
 
@@ -23,9 +23,9 @@ class Annotation
     {
         self::validate($data);
         $instance = new self();
-        $instance->id = $data['id'];
-        $instance->image_id = $data['image_id'];
-        $instance->category_id = $data['category_id'];
+        $instance->id = (string) $data['id'];
+        $instance->image_id = (string) $data['image_id'];
+        $instance->category_id = (string) $data['category_id'];
 
         if (isset($data['segmentation'])){
             $instance->segmentation = is_array($data['segmentation'][0]) ? $data['segmentation'][0] : $data['segmentation'];

--- a/src/Category.php
+++ b/src/Category.php
@@ -4,7 +4,7 @@ namespace Biigle\Modules\MetadataCoco;
 
 class Category
 {
-    public int $id;
+    public string $id;
     public string $name;
 
     // Static create method from JSON
@@ -12,7 +12,7 @@ class Category
     {
         self::validate($data);
         $instance = new self();
-        $instance->id = $data['id'];
+        $instance->id = (string) $data['id'];
         $instance->name = $data['name'];
 
         return $instance;

--- a/src/Category.php
+++ b/src/Category.php
@@ -31,5 +31,9 @@ class Category
                 throw new \Exception("Missing value for '$key' in Category");
             }
         }
+
+        if (!is_scalar($data['id'])) {
+            throw new \Exception("Invalid value for 'id' in Category");
+        }
     }
 }

--- a/src/Coco.php
+++ b/src/Coco.php
@@ -86,7 +86,7 @@ class Coco
         }, $this->categories);
 
         foreach ($this->annotations as $annotation) {
-            if (!in_array($annotation->category_id, $categoryIds)) {
+            if (!in_array($annotation->category_id, $categoryIds, true)) {
                 throw new \Exception("Invalid category ID '{$annotation->category_id}' in annotation '{$annotation->id}'");
             }
         }
@@ -99,7 +99,7 @@ class Coco
         }, $this->images);
 
         foreach ($this->annotations as $annotation) {
-            if (!in_array($annotation->image_id, $imageIds)) {
+            if (!in_array($annotation->image_id, $imageIds, true)) {
                 throw new \Exception("Invalid image ID '{$annotation->image_id}' in annotation '{$annotation->id}'");
             }
         }

--- a/src/Coco.php
+++ b/src/Coco.php
@@ -81,12 +81,8 @@ class Coco
 
     public function validateCategoriesInData(): void
     {
-        $categoryIds = array_map(function ($category) {
-            return $category->id;
-        }, $this->categories);
-
         foreach ($this->annotations as $annotation) {
-            if (!in_array($annotation->category_id, $categoryIds, true)) {
+            if (!array_key_exists($annotation->category_id, $this->categories)) {
                 throw new \Exception("Invalid category ID '{$annotation->category_id}' in annotation '{$annotation->id}'");
             }
         }
@@ -94,12 +90,12 @@ class Coco
 
     public function validateImagesInData(): void
     {
-        $imageIds = array_map(function ($image) {
+        $imageIds = array_flip(array_map(function ($image) {
             return $image->id;
-        }, $this->images);
+        }, $this->images));
 
         foreach ($this->annotations as $annotation) {
-            if (!in_array($annotation->image_id, $imageIds, true)) {
+            if (!array_key_exists($annotation->image_id, $imageIds)) {
                 throw new \Exception("Invalid image ID '{$annotation->image_id}' in annotation '{$annotation->id}'");
             }
         }

--- a/src/Image.php
+++ b/src/Image.php
@@ -4,7 +4,7 @@ namespace Biigle\Modules\MetadataCoco;
 
 class Image
 {
-    public int $id;
+    public string $id;
     public int $width;
     public int $height;
     public string $file_name;
@@ -19,7 +19,7 @@ class Image
     {
         self::validate($data);
         $instance = new self();
-        $instance->id = $data['id'];
+        $instance->id = (string) $data['id'];
         $instance->width = $data['width'];
         $instance->height = $data['height'];
         $instance->file_name = $data['file_name'];

--- a/src/Image.php
+++ b/src/Image.php
@@ -44,5 +44,9 @@ class Image
                 throw new \Exception("Missing value for '$key' in Image");
             }
         }
+
+        if (!is_scalar($data['id'])) {
+            throw new \Exception("Invalid value for 'id' in Image");
+        }
     }
 }

--- a/tests/CocoParserTest.php
+++ b/tests/CocoParserTest.php
@@ -472,4 +472,40 @@ class CocoParserTest extends TestCase
         ];
         $this->assertSame($expectedPoints, $rectangleAnnotation->getPoints());
     }
+
+    public function testCreateWithStringIds()
+    {
+        $coco = Coco::create([
+            'images' => [
+                [
+                    'id' => 'image-1',
+                    'width' => 100,
+                    'height' => 200,
+                    'file_name' => 'image.jpg',
+                ],
+            ],
+            'annotations' => [
+                [
+                    'id' => 'annotation-1',
+                    'image_id' => 'image-1',
+                    'category_id' => 'category-1',
+                    'bbox' => [10, 20, 30, 40],
+                ],
+            ],
+            'categories' => [
+                [
+                    'id' => 'category-1',
+                    'name' => 'Animal',
+                ],
+            ],
+        ]);
+
+        $this->assertSame('image-1', $coco->images[0]->id);
+        $this->assertSame('annotation-1', $coco->annotations[0]->id);
+        $this->assertSame('image-1', $coco->annotations[0]->image_id);
+        $this->assertSame('category-1', $coco->annotations[0]->category_id);
+        $this->assertArrayHasKey('category-1', $coco->categories);
+        $this->assertSame('category-1', $coco->categories['category-1']->id);
+        $this->assertSame('Animal', $coco->annotations[0]->getLabel($coco->categories)->name);
+    }
 }

--- a/tests/CocoParserTest.php
+++ b/tests/CocoParserTest.php
@@ -4,8 +4,10 @@ namespace Biigle\Tests\Modules\MetadataCoco;
 
 use Biigle\MediaType;
 use Biigle\Modules\MetadataCoco\Annotation;
+use Biigle\Modules\MetadataCoco\Category;
 use Biigle\Modules\MetadataCoco\Coco;
 use Biigle\Modules\MetadataCoco\CocoParser;
+use Biigle\Modules\MetadataCoco\Image;
 use Biigle\Modules\MetadataCoco\Info;
 use Biigle\Shape;
 use Exception;
@@ -507,5 +509,63 @@ class CocoParserTest extends TestCase
         $this->assertArrayHasKey('category-1', $coco->categories);
         $this->assertSame('category-1', $coco->categories['category-1']->id);
         $this->assertSame('Animal', $coco->annotations[0]->getLabel($coco->categories)->name);
+    }
+
+    public function testValidateImageRejectsNonScalarId()
+    {
+        $this->expectException(Exception::class);
+
+        Image::validate([
+            'id' => ['image-1'],
+            'width' => 100,
+            'height' => 200,
+            'file_name' => 'image.jpg',
+        ]);
+    }
+
+    public function testValidateCategoryRejectsNonScalarId()
+    {
+        $this->expectException(Exception::class);
+
+        Category::validate([
+            'id' => ['category-1'],
+            'name' => 'Animal',
+        ]);
+    }
+
+    public function testValidateAnnotationRejectsNonScalarId()
+    {
+        $this->expectException(Exception::class);
+
+        Annotation::validate([
+            'id' => ['annotation-1'],
+            'image_id' => 'image-1',
+            'category_id' => 'category-1',
+            'bbox' => [10, 20, 30, 40],
+        ]);
+    }
+
+    public function testValidateAnnotationRejectsEmptySegmentationWithoutBbox()
+    {
+        $this->expectException(Exception::class);
+
+        Annotation::validate([
+            'id' => 'annotation-1',
+            'image_id' => 'image-1',
+            'category_id' => 'category-1',
+            'segmentation' => [],
+        ]);
+    }
+
+    public function testValidateAnnotationRejectsNonArraySegmentation()
+    {
+        $this->expectException(Exception::class);
+
+        Annotation::validate([
+            'id' => 'annotation-1',
+            'image_id' => 'image-1',
+            'category_id' => 'category-1',
+            'segmentation' => 'invalid',
+        ]);
     }
 }


### PR DESCRIPTION
Fixes #14

COCO files may use string values for image, annotation and category IDs. 
So, normalized these IDs to strings when parsing so typed properties and strict consistency checks handle both numeric and string identifiers.

